### PR TITLE
skeleton of adding a thread pool to make the multi-threading, uh, pooled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,10 +58,11 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "bippy"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
+ "ctrlc",
  "tempfile",
 ]
 
@@ -82,6 +83,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "clap"
@@ -130,6 +137,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "ctrlc"
+version = "3.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "672465ae37dc1bc6380a6547a8883d5dd397b0f1faaad4f265726cc7042a5345"
+dependencies = [
+ "nix",
+ "windows-sys",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +179,18 @@ name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.2",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,5 @@ homepage = "https://github.com/alicewriteswrongs/bippy"
 [dependencies]
 anyhow = "1.0.79"
 clap = { version = "4.4.18", features = ["derive"] }
+ctrlc = "3.4.4"
 tempfile = "3.9.0"

--- a/src/interrupt.rs
+++ b/src/interrupt.rs
@@ -1,0 +1,17 @@
+use std::sync::mpsc::{channel, Receiver};
+
+/// Set up a ctrl-c interrupt 'listener' which can then be checked later on in e.g. a loop to see
+/// if the user has tried to interrupt the program or not.
+///
+/// The message sent in the mpsc channel doesn't matter, so it's just a unit, we only care if a
+/// message has actually been sent.
+pub fn ctrlc_channel() -> Receiver<()> {
+    let (sender, receiver) = channel::<()>();
+
+    ctrlc::set_handler(move || {
+        sender.send(()).expect("could not send into ctrl-c channel");
+    })
+    .expect("could not set up ctrl-c interrupt handler");
+
+    receiver
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,12 @@ use clap::Parser;
 
 mod cli;
 mod http;
+mod interrupt;
 mod parser;
 mod request;
 mod response;
 mod server;
+mod threadpool;
 
 use cli::CLIArgs;
 use server::Server;

--- a/src/server/file.rs
+++ b/src/server/file.rs
@@ -40,8 +40,8 @@ fn derive_file_path(serve_path: &Path, request_path: &str) -> Result<PathBuf> {
 mod tests {
     use super::*;
     use anyhow::Result;
-    use tempfile::TempDir;
     use std::fs;
+    use tempfile::TempDir;
 
     #[test]
     fn derive_file_path_adds_index_to_dir() -> Result<()> {
@@ -56,7 +56,7 @@ mod tests {
         let dir = TempDir::new()?;
         let route_path = dir.path().to_owned().join("/route");
         fs::create_dir(&route_path)?;
-        
+
         let derived = derive_file_path(&dir.path(), "/route")?;
         assert!(derived == route_path.join("index.html"));
         Ok(())

--- a/src/threadpool.rs
+++ b/src/threadpool.rs
@@ -1,0 +1,109 @@
+use anyhow::{anyhow, Result};
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+
+pub struct ThreadPool {
+    workers: Vec<Worker>,
+    sender: Sender<Message>,
+}
+
+type Job = Box<dyn FnOnce() -> Result<()> + Send + 'static>;
+
+enum Message {
+    Work(Job),
+    Exit,
+}
+
+impl ThreadPool {
+    pub fn new(num_threads: usize) -> Result<ThreadPool> {
+        if num_threads == 0 {
+            return Err(anyhow!(
+                "Tried to construct a thread pool with zero threads 🤔"
+            ));
+        }
+
+        let mut workers = Vec::with_capacity(num_threads);
+        let (sender, receiver) = channel::<Message>();
+        let receiver = Arc::new(Mutex::new(receiver));
+
+        for id in 0..num_threads {
+            workers.push(Worker::new(id, receiver.clone()));
+        }
+
+        Ok(ThreadPool { workers, sender })
+    }
+
+    pub fn execute<F>(&self, job: F)
+    where
+        F: FnOnce() -> Result<()> + Send + 'static,
+    {
+        let job = Box::new(job);
+        self.sender
+            .send(Message::Work(job))
+            .expect("should be able to send a job to a worker");
+    }
+}
+
+/// Need to make sure that threads are cleaned up when they are dropped!
+impl Drop for ThreadPool {
+    fn drop(&mut self) {
+        for _ in &mut self.workers {
+            self.sender
+                .send(Message::Exit)
+                .expect("couldn't sent 'exit' message to worker");
+        }
+
+        for worker in &mut self.workers {
+            if let Some(thread) = worker.thread.take() {
+                thread.join().expect(
+                    "should be able to gracefully kill a worker thread",
+                );
+                if cfg!(debug_assertions) {
+                    println!("successfully killed {}", worker.id);
+                }
+            }
+        }
+    }
+}
+
+struct Worker {
+    thread: Option<JoinHandle<()>>,
+    id: usize,
+}
+
+impl Worker {
+    fn new(id: usize, receiver: Arc<Mutex<Receiver<Message>>>) -> Worker {
+        let thread = thread::spawn(move || {
+            if cfg!(debug_assertions) {
+                println!(
+                    "creating thread {}, {}",
+                    id,
+                    thread::current().id().as_u64()
+                );
+            }
+
+            loop {
+                let message = receiver
+                    .lock()
+                    .expect("should be able to lock mutex in worker")
+                    .recv()
+                    .expect("should be able to receive job in worker");
+
+                match message {
+                    Message::Work(job) => {
+                        job().unwrap();
+                    }
+                    Message::Exit => {
+                        break;
+                    }
+                }
+            }
+        });
+
+        Worker {
+            id,
+            thread: Some(thread),
+        }
+    }
+}


### PR DESCRIPTION
This adds proper multi-threading to Bippy.

I based the implementation on the code in [chapter 20 of the Rust book](https://doc.rust-lang.org/book/ch20-00-final-project-a-web-server.html) but changed things to make the TCP listener handling code non-blocking. This allows the webserver to correctly handle ctrl-c interrupts and thereby clean up after itself, rather than leaving orphan threads around for the OS to clean up later.